### PR TITLE
Use batching when receiving GUILD_EMOJIS_UPDATE event 

### DIFF
--- a/src/storageEngine/RedisStorageEngine.js
+++ b/src/storageEngine/RedisStorageEngine.js
@@ -119,8 +119,8 @@ class RedisStorageEngine extends BaseStorageEngine {
                 if (!cachedData) {
                     cachedData = {};
                 }
-                data = Object.assign(cachedData, data[index]);
-                args.push(id, this.prepareData(data));
+                const updatedCacheData = Object.assign(cachedData, data[index]);
+                args.push(id, this.prepareData(updatedCacheData));
             });
             return this.client.msetAsync(...args);
         }


### PR DESCRIPTION
also fixes a weird bug where emojis that were cached during GUILD_CREATE were saved with {} in the cache